### PR TITLE
Fixing build issue for Windows

### DIFF
--- a/lib/browser-view-factory.js
+++ b/lib/browser-view-factory.js
@@ -209,7 +209,7 @@ new ViewGlobals({
      * @return {Promise.<Array>}
      */
     static async create(input, opts = {}) {
-        const pattern = path.join(process.cwd(), input || DEFAULT_INPUT);
+        const pattern = path.join(process.cwd(), input || DEFAULT_INPUT).replace(/\\/g, '/');
         const absoluteFilenames = await fastGlob(pattern);
         const legacy = opts.legacy != null ? opts.legacy : true;
 

--- a/lib/browser-view-factory.js
+++ b/lib/browser-view-factory.js
@@ -51,8 +51,8 @@ class BrowserViewFactory {
         const viewGlobalsRelativePath = path.relative(path.dirname(wrappedAbsoluteFilename), __dirname + '/components') + '/ViewGlobals.svelte';
 
         return `
-import ViewGlobals from '${viewGlobalsRelativePath}';
-import ViewComponent from '${relativeFilename}';
+import ViewGlobals from '${viewGlobalsRelativePath.replace(/\\/g, '/')}';
+import ViewComponent from '${relativeFilename.replace(/\\/g, '/')}';
 const [ target = document.body ] = document.getElementsByClassName('view-target');
 const [ anchor = null ] = document.getElementsByClassName('view-anchor');
 

--- a/lib/express-svelte.js
+++ b/lib/express-svelte.js
@@ -80,7 +80,7 @@ function expressSvelte(mainOpts = {}) {
     async function svelteCompile(name, options = {}) {
         try {
             // Lookup view with express view engine like logic
-            const filename = await Utils.lookup(name, viewsDirname, defaultExtension);
+            const filename = (await Utils.lookup(name, viewsDirname, defaultExtension)).replace(/\\/g, '/');
 
             if (filename == null) {
                 const err = new Error(`Failed to lookup view "${name}" in views directories ${JSON.stringify(viewsDirname)}`);


### PR DESCRIPTION
There is a rollup error when building on Windows. If you look at the fast-glob documentation, it outlines the fix that needs to be made.

https://www.npmjs.com/package/fast-glob#how-to-write-patterns-on-windows